### PR TITLE
Refactor service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -567,5 +567,3 @@ MigrationBackup/
 
 **/**/.DS_Store
 
-WombatProject/appsettings.json
-

--- a/WombatProject/Controllers/AuthorController.cs
+++ b/WombatProject/Controllers/AuthorController.cs
@@ -21,7 +21,7 @@ namespace WombatLibrarianApi.Controllers
         [HttpGet("{author}")]
         public async Task<ActionResult<IEnumerable<Book>>> GetAuthorBookItems(string author)
         {
-            await _apiService.GetAuthorBooks(author);
+            await _apiService.GetAuthorBooksAsync(author);
             return _apiService.AuthorBookItems;
         }
     }

--- a/WombatProject/Controllers/BookshelvesController.cs
+++ b/WombatProject/Controllers/BookshelvesController.cs
@@ -22,7 +22,7 @@ namespace WombatLibrarianApi.Controllers
         [HttpGet]
         public async Task<IActionResult> GetBookshelfItems()
         {
-            var books = await _repository.GetBooksFromBookshelf();
+            var books = await _repository.GetBooksFromBookshelfAsync();
             return Ok(books);
         }
 
@@ -44,30 +44,24 @@ namespace WombatLibrarianApi.Controllers
         [HttpPost]
         public async Task<ActionResult<Bookshelf>> AddItemToBookshelf(Book book)
         {
-            var bookshelf = await _repository.AddBookToBookshelf(book);
+            var bookshelf = await _repository.AddBookToBookshelfAsync(book);
 
-            return CreatedAtAction("GetBookshelf", new { id = bookshelf.Id }, bookshelf);
+            return CreatedAtAction("GetBookshelfItemById", new { id = bookshelf.Id }, bookshelf);
         }
 
         // DELETE: api/Bookshelves/5
         [HttpDelete("{id}")]
         public async Task<IActionResult> RemoveBookFromBookshelf(int id)
         {
-            var bookshelf = await _repository.Context.Bookshelves.FindAsync(id);
+            var bookshelf = await _repository.GetBookshelfItemByIdAsync(id);
             if (bookshelf == null)
             {
                 return NotFound();
             }
 
-            _repository.Context.Bookshelves.Remove(bookshelf);
-            await _repository.Context.SaveChangesAsync();
+           await _repository.RemoveBookFromBookshelfById(bookshelf);
 
             return NoContent();
-        }
-
-        private bool BookshelfExists(int id)
-        {
-            return _repository.Context.Bookshelves.Any(e => e.Id == id);
         }
     }
 }

--- a/WombatProject/Controllers/BookshelvesController.cs
+++ b/WombatProject/Controllers/BookshelvesController.cs
@@ -40,44 +40,6 @@ namespace WombatLibrarianApi.Controllers
             return bookshelf;
         }
 
-        // PUT: api/Bookshelves/5
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
-        [HttpPut("{id}")]
-        public async Task<IActionResult> PutBookshelf(int id, Bookshelf bookshelf)
-        {
-            // validate input params -> id != bookshelf.Id -> return BadRequest();
-            // try {
-            // _repository.UpdateBookShelf(id, bookshelf);
-            // } catch (ArgumentException ex){
-            //  return NotFound();
-            // }
-            // return NoContent();
-            if (id != bookshelf.Id)
-            {
-                return BadRequest();
-            }
-
-            _repository.Context.Entry(bookshelf).State = EntityState.Modified;
-
-            try
-            {
-                await _repository.Context.SaveChangesAsync();
-            }
-            catch (DbUpdateConcurrencyException)
-            {
-                if (!BookshelfExists(id))
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            return NoContent();
-        }
-
         // POST: api/Bookshelves
         // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]

--- a/WombatProject/Controllers/BookshelvesController.cs
+++ b/WombatProject/Controllers/BookshelvesController.cs
@@ -20,7 +20,7 @@ namespace WombatLibrarianApi.Controllers
 
         // GET: api/Bookshelves
         [HttpGet]
-        public async Task<IActionResult> GetBookshelves()
+        public async Task<IActionResult> GetBookshelfItems()
         {
             var books = await _repository.GetBooksFromBookshelf();
             return Ok(books);
@@ -28,9 +28,9 @@ namespace WombatLibrarianApi.Controllers
 
         // GET: api/Bookshelves/5
         [HttpGet("{id}")]
-        public async Task<ActionResult<Bookshelf>> GetBookshelf(int id)
+        public async Task<ActionResult<Bookshelf>> GetBookshelfItemById(int id)
         {
-            var bookshelf = await _repository.GetBookShelveByIdAsync(id);
+            var bookshelf = await _repository.GetBookshelfItemByIdAsync(id);
 
             if (bookshelf == null)
             {
@@ -41,9 +41,8 @@ namespace WombatLibrarianApi.Controllers
         }
 
         // POST: api/Bookshelves
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]
-        public async Task<ActionResult<Bookshelf>> PostBookshelf(Book book)
+        public async Task<ActionResult<Bookshelf>> AddItemToBookshelf(Book book)
         {
             var bookshelf = await _repository.AddBookToBookshelf(book);
 
@@ -52,7 +51,7 @@ namespace WombatLibrarianApi.Controllers
 
         // DELETE: api/Bookshelves/5
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteBookshelf(int id)
+        public async Task<IActionResult> RemoveBookFromBookshelf(int id)
         {
             var bookshelf = await _repository.Context.Bookshelves.FindAsync(id);
             if (bookshelf == null)

--- a/WombatProject/Controllers/BookshelvesController.cs
+++ b/WombatProject/Controllers/BookshelvesController.cs
@@ -51,7 +51,7 @@ namespace WombatLibrarianApi.Controllers
 
         // DELETE: api/Bookshelves/5
         [HttpDelete("{id}")]
-        public async Task<IActionResult> RemoveBookFromBookshelf(int id)
+        public async Task<IActionResult> RemoveBookFromBookshelfById(int id)
         {
             var bookshelf = await _repository.GetBookshelfItemByIdAsync(id);
             if (bookshelf == null)

--- a/WombatProject/Controllers/BookshelvesController.cs
+++ b/WombatProject/Controllers/BookshelvesController.cs
@@ -59,7 +59,7 @@ namespace WombatLibrarianApi.Controllers
                 return NotFound();
             }
 
-           await _repository.RemoveBookFromBookshelfById(bookshelf);
+           await _repository.RemoveBookFromBookshelfByIdAsync(bookshelf);
 
             return NoContent();
         }

--- a/WombatProject/Controllers/SearchController.cs
+++ b/WombatProject/Controllers/SearchController.cs
@@ -21,7 +21,7 @@ namespace WombatLibrarianApi.Controllers
         [HttpGet("{searchTerm}")]
         public async Task<ActionResult<IEnumerable<Book>>> GetBookItems(string searchTerm)
         {
-            await _apiService.GetSearchResults(searchTerm);
+            await _apiService.GetSearchResultsAsync(searchTerm);
             return _apiService.SearchResults;
         }
     }

--- a/WombatProject/Controllers/WishlistsController.cs
+++ b/WombatProject/Controllers/WishlistsController.cs
@@ -49,25 +49,19 @@ namespace WombatLibrarianApi.Controllers
             return CreatedAtAction("GetWishlistItemById", new { id = wishlist.Id }, wishlist);
         }
 
-        //// DELETE: api/Wishlists/5
-        //[HttpDelete("{id}")]
-        //public async Task<IActionResult> RemoveBookFromWishlist(int id)
-        //{
-        //    var wishlist = await _repository.Context.Wishlists.FindAsync(id);
-        //    if (wishlist == null)
-        //    {
-        //        return NotFound();
-        //    }
+        // DELETE: api/Wishlists/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> RemoveBookFromWishlist(int id)
+        {
+            var wishlist = await _repository.GetWishlistItemByIdAsync(id);
+            if (wishlist == null)
+            {
+                return NotFound();
+            }
 
-        //    _repository.Context.Wishlists.Remove(wishlist);
-        //    await _repository.Context.SaveChangesAsync();
+            await _repository.RemoveBookFromWishlistByIdAsync(wishlist);
 
-        //    return NoContent();
-        //}
-
-        //private bool WishlistExists(int id)
-        //{
-        //    return _repository.Context.Wishlists.Any(e => e.Id == id);
-        //}
+            return NoContent();
+        }
     }
 }

--- a/WombatProject/Controllers/WishlistsController.cs
+++ b/WombatProject/Controllers/WishlistsController.cs
@@ -15,20 +15,20 @@ namespace WombatLibrarianApi.Controllers
 
         public WishlistsController(IBookRepository repository)
         {
-            _repository = repository;
+            this._repository = repository;
         }
 
         // GET: api/Wishlists
         [HttpGet]
-        public async Task<IActionResult> GetWishlists()
+        public async Task<IActionResult> GetWishlistItems()
         {
-            var books = await _repository.GetBooksFromWishlist();
+            var books = await _repository.GetBooksFromWishlistAsync();
             return Ok(books);
         }
 
         // GET: api/Wishlists/5
         [HttpGet("{id}")]
-        public async Task<ActionResult<Wishlist>> GetWishlist(int id)
+        public async Task<ActionResult<Wishlist>> GetWishlistItemById(int id)
         {
             var wishlist = await _repository.Context.Wishlists.FindAsync(id);
 
@@ -40,50 +40,18 @@ namespace WombatLibrarianApi.Controllers
             return wishlist;
         }
 
-        // PUT: api/Wishlists/5
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
-        [HttpPut("{id}")]
-        public async Task<IActionResult> PutWishlist(int id, Wishlist wishlist)
-        {
-            if (id != wishlist.Id)
-            {
-                return BadRequest();
-            }
-
-            _repository.Context.Entry(wishlist).State = EntityState.Modified;
-
-            try
-            {
-                await _repository.Context.SaveChangesAsync();
-            }
-            catch (DbUpdateConcurrencyException)
-            {
-                if (!WishlistExists(id))
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            return NoContent();
-        }
-
         // POST: api/Wishlists
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]
-        public async Task<ActionResult<Wishlist>> PostWishlist(Book book)
+        public async Task<ActionResult<Wishlist>> AddItemToWishlist(Book book)
         {
-            var wishlist = await _repository.AddBookToWishlist(book);
+            var wishlist = await _repository.AddBookToWishlistAsync(book);
 
-            return CreatedAtAction("GetWishlist", new { id = wishlist.Id }, wishlist);
+            return CreatedAtAction("GetWishlistItemById", new { id = wishlist.Id }, wishlist);
         }
 
         // DELETE: api/Wishlists/5
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteWishlist(int id)
+        public async Task<IActionResult> RemoveBookFromWishlist(int id)
         {
             var wishlist = await _repository.Context.Wishlists.FindAsync(id);
             if (wishlist == null)

--- a/WombatProject/Controllers/WishlistsController.cs
+++ b/WombatProject/Controllers/WishlistsController.cs
@@ -51,7 +51,7 @@ namespace WombatLibrarianApi.Controllers
 
         // DELETE: api/Wishlists/5
         [HttpDelete("{id}")]
-        public async Task<IActionResult> RemoveBookFromWishlist(int id)
+        public async Task<IActionResult> RemoveBookFromWishlistById(int id)
         {
             var wishlist = await _repository.GetWishlistItemByIdAsync(id);
             if (wishlist == null)

--- a/WombatProject/Controllers/WishlistsController.cs
+++ b/WombatProject/Controllers/WishlistsController.cs
@@ -30,7 +30,7 @@ namespace WombatLibrarianApi.Controllers
         [HttpGet("{id}")]
         public async Task<ActionResult<Wishlist>> GetWishlistItemById(int id)
         {
-            var wishlist = await _repository.Context.Wishlists.FindAsync(id);
+            var wishlist = await _repository.GetWishlistItemByIdAsync(id);
 
             if (wishlist == null)
             {

--- a/WombatProject/Controllers/WishlistsController.cs
+++ b/WombatProject/Controllers/WishlistsController.cs
@@ -49,25 +49,25 @@ namespace WombatLibrarianApi.Controllers
             return CreatedAtAction("GetWishlistItemById", new { id = wishlist.Id }, wishlist);
         }
 
-        // DELETE: api/Wishlists/5
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> RemoveBookFromWishlist(int id)
-        {
-            var wishlist = await _repository.Context.Wishlists.FindAsync(id);
-            if (wishlist == null)
-            {
-                return NotFound();
-            }
+        //// DELETE: api/Wishlists/5
+        //[HttpDelete("{id}")]
+        //public async Task<IActionResult> RemoveBookFromWishlist(int id)
+        //{
+        //    var wishlist = await _repository.Context.Wishlists.FindAsync(id);
+        //    if (wishlist == null)
+        //    {
+        //        return NotFound();
+        //    }
 
-            _repository.Context.Wishlists.Remove(wishlist);
-            await _repository.Context.SaveChangesAsync();
+        //    _repository.Context.Wishlists.Remove(wishlist);
+        //    await _repository.Context.SaveChangesAsync();
 
-            return NoContent();
-        }
+        //    return NoContent();
+        //}
 
-        private bool WishlistExists(int id)
-        {
-            return _repository.Context.Wishlists.Any(e => e.Id == id);
-        }
+        //private bool WishlistExists(int id)
+        //{
+        //    return _repository.Context.Wishlists.Any(e => e.Id == id);
+        //}
     }
 }

--- a/WombatProject/Models/WombatBooksContext.cs
+++ b/WombatProject/Models/WombatBooksContext.cs
@@ -5,18 +5,17 @@ namespace WombatLibrarianApi.Models
 {
     public class WombatBooksContext : DbContext
     {
-        public WombatBooksContext(DbContextOptions<WombatBooksContext> options, IConfiguration configuration) : base(options)
-        {
-            _configuration = configuration;
-        }
-
         private IConfiguration _configuration;
-
         public DbSet<Book> Books { get; set; }
         public DbSet<Author> Authors { get; set; }
         public DbSet<Category> Categories { get; set; }
         public DbSet<Bookshelf> Bookshelves { get; set; }
         public DbSet<Wishlist> Wishlists { get; set; }
+
+        public WombatBooksContext(DbContextOptions<WombatBooksContext> options, IConfiguration configuration) : base(options)
+        {
+            _configuration = configuration;
+        }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) 
             => optionsBuilder.UseSqlServer(_configuration.GetConnectionString("databaseConnection"));

--- a/WombatProject/Program.cs
+++ b/WombatProject/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -11,6 +12,13 @@ namespace WombatLibrarianApi
 {
     public class Program
     {
+        public static IConfiguration Configuration { get; } = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .Build();
+
         public static void Main(string[] args)
         {
             CreateHostBuilder(args).Build().Run();

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -64,10 +64,10 @@ namespace WombatLibrarianApi.Services
             return bookshelf;
         }
 
-        public async Task<int> RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf)
+        public async Task RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf)
         {
             _context.Bookshelves.Remove(bookshelf);
-            return await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
         }
 
         public async Task<IEnumerable<object>> GetBooksFromWishlistAsync()
@@ -120,10 +120,10 @@ namespace WombatLibrarianApi.Services
             return wishlist;
         }
 
-        public async Task<int> RemoveBookFromWishlistByIdAsync(Wishlist wishlist)
+        public async Task RemoveBookFromWishlistByIdAsync(Wishlist wishlist)
         {
             _context.Wishlists.Remove(wishlist);
-            return await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -8,21 +8,21 @@ namespace WombatLibrarianApi.Services
 {
     public class BookRepository : IBookRepository
     {
-        public WombatBooksContext Context { get; }
+        protected WombatBooksContext _context { get; }
 
         public BookRepository(WombatBooksContext context)
         {
-            Context = context;
+            _context = context;
         }
 
         public async Task<IEnumerable<object>> GetBooksFromBookshelfAsync()
         {
-            var bookIds = Context.Bookshelves.Select(book => book.BookId).ToList();
-            return await Context.Books
+            var bookIds = _context.Bookshelves.Select(book => book.BookId).ToList();
+            return await _context.Books
                 .Where(book => bookIds.Contains(book.Id))
                 .Include(bookShelfItem => bookShelfItem.Authors)
                 .Include(bookShelfItem => bookShelfItem.Categories)
-                .Join(Context.Bookshelves,
+                .Join(_context.Bookshelves,
                 book => book.Id,
                 bookshelf => bookshelf.BookId,
                 (book, bookshelf) => new
@@ -46,39 +46,38 @@ namespace WombatLibrarianApi.Services
 
         public async Task<Bookshelf> GetBookshelfItemByIdAsync(int id)
         {
-            return await Context.Bookshelves.FindAsync(id);
+            return await _context.Bookshelves.FindAsync(id);
         }
 
         public async Task<Bookshelf> AddBookToBookshelfAsync(Book book)
         {
-            var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
+            var bookItem = _context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
             if (bookItem == null)
             {
-                Context.Authors.AddRange(book.Authors);
-                Context.Categories.AddRange(book.Categories);
-                Context.Books.Add(book);
+                _context.Authors.AddRange(book.Authors);
+                _context.Categories.AddRange(book.Categories);
+                _context.Books.Add(book);
             }
-            Bookshelf bookshelf = new Bookshelf() { BookId = book.Id };
-            Context.Bookshelves.Add(bookshelf);
-            await Context.SaveChangesAsync();
+            var bookshelf = new Bookshelf() { BookId = book.Id };
+            _context.Bookshelves.Add(bookshelf);
+            await _context.SaveChangesAsync();
             return bookshelf;
-
         }
 
         public async Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf)
         {
-            Context.Bookshelves.Remove(bookshelf);
-            return await Context.SaveChangesAsync();
+            _context.Bookshelves.Remove(bookshelf);
+            return await _context.SaveChangesAsync();
         }
 
         public async Task<IEnumerable<object>> GetBooksFromWishlistAsync()
         {
-            var bookIds = Context.Wishlists.Select(book => book.BookId).ToList();
-            return await Context.Books
+            var bookIds = _context.Wishlists.Select(book => book.BookId).ToList();
+            return await _context.Books
                 .Where(book => bookIds.Contains(book.Id))
                 .Include(wishlistItem => wishlistItem.Authors)
                 .Include(wishlistItem => wishlistItem.Categories)
-                .Join(Context.Wishlists,
+                .Join(_context.Wishlists,
                 book => book.Id,
                 wishlist => wishlist.BookId,
                 (book, wishlist) => new
@@ -102,22 +101,22 @@ namespace WombatLibrarianApi.Services
 
         public async Task<Wishlist> GetWishlistItemByIdAsync(int id)
         {
-            return await Context.Wishlists.FindAsync(id);
+            return await _context.Wishlists.FindAsync(id);
         }
 
         public async Task<Wishlist> AddBookToWishlistAsync(Book book)
         {
-            var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
+            var bookItem = _context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
 
             if (bookItem == null)
             {
-                Context.Authors.AddRange(book.Authors);
-                Context.Categories.AddRange(book.Categories);
-                Context.Books.Add(book);
+                _context.Authors.AddRange(book.Authors);
+                _context.Categories.AddRange(book.Categories);
+                _context.Books.Add(book);
             }
             Wishlist wishlist = new Wishlist() { BookId = book.Id };
-            Context.Wishlists.Add(wishlist);
-            await Context.SaveChangesAsync();
+            _context.Wishlists.Add(wishlist);
+            await _context.SaveChangesAsync();
             return wishlist;
         }
     }

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -100,6 +100,11 @@ namespace WombatLibrarianApi.Services
                 .ToListAsync();
         }
 
+        public async Task<Wishlist> GetWishlistItemByIdAsync(int id)
+        {
+            return await Context.Wishlists.FindAsync(id);
+        }
+
         public async Task<Wishlist> AddBookToWishlistAsync(Book book)
         {
             var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -64,7 +64,7 @@ namespace WombatLibrarianApi.Services
             return bookshelf;
         }
 
-        public async Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf)
+        public async Task<int> RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf)
         {
             _context.Bookshelves.Remove(bookshelf);
             return await _context.SaveChangesAsync();
@@ -114,10 +114,16 @@ namespace WombatLibrarianApi.Services
                 _context.Categories.AddRange(book.Categories);
                 _context.Books.Add(book);
             }
-            Wishlist wishlist = new Wishlist() { BookId = book.Id };
+            var wishlist = new Wishlist() { BookId = book.Id };
             _context.Wishlists.Add(wishlist);
             await _context.SaveChangesAsync();
             return wishlist;
+        }
+
+        public async Task<int> RemoveBookFromWishlistByIdAsync(Wishlist wishlist)
+        {
+            _context.Wishlists.Remove(wishlist);
+            return await _context.SaveChangesAsync();
         }
     }
 }

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -101,7 +101,7 @@ namespace WombatLibrarianApi.Services
             await Context.SaveChangesAsync();
             return wishlist;
         }
-        public async Task<Bookshelf> GetBookShelveByIdAsync(int id)
+        public async Task<Bookshelf> GetBookshelfItemByIdAsync(int id)
         {
             return await Context.Bookshelves.FindAsync(id);
         }

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -15,7 +15,7 @@ namespace WombatLibrarianApi.Services
             Context = context;
         }
 
-        public async Task<IEnumerable<object>> GetBooksFromBookshelf()
+        public async Task<IEnumerable<object>> GetBooksFromBookshelfAsync()
         {
             var bookIds = Context.Bookshelves.Select(book => book.BookId).ToList();
             return await Context.Books
@@ -43,7 +43,13 @@ namespace WombatLibrarianApi.Services
                 })
                 .ToListAsync();
         }
-        public async Task<Bookshelf> AddBookToBookshelf(Book book)
+
+        public async Task<Bookshelf> GetBookshelfItemByIdAsync(int id)
+        {
+            return await Context.Bookshelves.FindAsync(id);
+        }
+
+        public async Task<Bookshelf> AddBookToBookshelfAsync(Book book)
         {
             var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
             if (bookItem == null)
@@ -58,6 +64,13 @@ namespace WombatLibrarianApi.Services
             return bookshelf;
 
         }
+
+        public async Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf)
+        {
+            Context.Bookshelves.Remove(bookshelf);
+            return await Context.SaveChangesAsync();
+        }
+
         public async Task<IEnumerable<object>> GetBooksFromWishlist()
         {
             var bookIds = Context.Wishlists.Select(book => book.BookId).ToList();
@@ -86,6 +99,7 @@ namespace WombatLibrarianApi.Services
                 })
                 .ToListAsync();
         }
+
         public async Task<Wishlist> AddBookToWishlist(Book book)
         {
             var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
@@ -100,10 +114,6 @@ namespace WombatLibrarianApi.Services
             Context.Wishlists.Add(wishlist);
             await Context.SaveChangesAsync();
             return wishlist;
-        }
-        public async Task<Bookshelf> GetBookshelfItemByIdAsync(int id)
-        {
-            return await Context.Bookshelves.FindAsync(id);
         }
     }
 }

--- a/WombatProject/Services/BookRepository.cs
+++ b/WombatProject/Services/BookRepository.cs
@@ -71,7 +71,7 @@ namespace WombatLibrarianApi.Services
             return await Context.SaveChangesAsync();
         }
 
-        public async Task<IEnumerable<object>> GetBooksFromWishlist()
+        public async Task<IEnumerable<object>> GetBooksFromWishlistAsync()
         {
             var bookIds = Context.Wishlists.Select(book => book.BookId).ToList();
             return await Context.Books
@@ -100,7 +100,7 @@ namespace WombatLibrarianApi.Services
                 .ToListAsync();
         }
 
-        public async Task<Wishlist> AddBookToWishlist(Book book)
+        public async Task<Wishlist> AddBookToWishlistAsync(Book book)
         {
             var bookItem = Context.Books.Where(item => item.Id == book.Id).FirstOrDefault();
 

--- a/WombatProject/Services/GoogleBooksAPIService.cs
+++ b/WombatProject/Services/GoogleBooksAPIService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -7,24 +8,25 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using WombatLibrarianApi.Models;
+using WombatLibrarianApi.Settings;
 
 namespace WombatLibrarianApi.Services
 {
     public class GoogleBooksAPIService : IBookAPIService
     {
-        private readonly IConfiguration _configuration;
+        protected readonly GoogleApiSettings _googleApiSettings;
         public List<Book> AuthorBookItems { get; } = new List<Book>();
         public List<Book> SearchResults { get; } = new List<Book>();
 
-        public GoogleBooksAPIService(IConfiguration configuration)
+        public GoogleBooksAPIService(IOptions<GoogleApiSettings> settings)
         {
-            _configuration = configuration;
+            this._googleApiSettings = settings.Value;
         }
 
         public async Task GetSearchResults(string searchTerm)
         {
             SearchResults.Clear();
-            string url = $"{_configuration["GBooksURL"]}?q={searchTerm}&maxResults=40";
+            string url = $"{_googleApiSettings.GoogleBooksURL}?q={searchTerm}&maxResults=40";
             IList<JToken> tokens = await GetBookItemsAsJToken(url);
             foreach (JToken token in tokens)
             {
@@ -35,7 +37,7 @@ namespace WombatLibrarianApi.Services
         public async Task GetAuthorBooks(string author)
         {
             AuthorBookItems.Clear();
-            string url = $"{_configuration["GBooksURL"]}?q=inauthor:{author}";
+            string url = $"{_googleApiSettings.GoogleBooksURL}?q=inauthor:{author}";
             IList<JToken> tokens = await GetBookItemsAsJToken(url);
             foreach (JToken token in tokens)
             {

--- a/WombatProject/Services/GoogleBooksAPIService.cs
+++ b/WombatProject/Services/GoogleBooksAPIService.cs
@@ -23,7 +23,7 @@ namespace WombatLibrarianApi.Services
             this._googleApiSettings = settings.Value;
         }
 
-        public async Task GetSearchResults(string searchTerm)
+        public async Task GetSearchResultsAsync(string searchTerm)
         {
             SearchResults.Clear();
             string url = $"{_googleApiSettings.GoogleBooksURL}?q={searchTerm}&maxResults=40";
@@ -34,7 +34,7 @@ namespace WombatLibrarianApi.Services
             }
         }
 
-        public async Task GetAuthorBooks(string author)
+        public async Task GetAuthorBooksAsync(string author)
         {
             AuthorBookItems.Clear();
             string url = $"{_googleApiSettings.GoogleBooksURL}?q=inauthor:{author}";

--- a/WombatProject/Services/IBookAPIService.cs
+++ b/WombatProject/Services/IBookAPIService.cs
@@ -8,7 +8,6 @@ namespace WombatLibrarianApi.Services
     {
         List<Book> SearchResults { get; }
         List<Book> AuthorBookItems { get; }
-        
         Task GetSearchResults(string searchTerm);
         Task GetAuthorBooks(string author);
     }

--- a/WombatProject/Services/IBookAPIService.cs
+++ b/WombatProject/Services/IBookAPIService.cs
@@ -8,7 +8,7 @@ namespace WombatLibrarianApi.Services
     {
         List<Book> SearchResults { get; }
         List<Book> AuthorBookItems { get; }
-        Task GetSearchResults(string searchTerm);
-        Task GetAuthorBooks(string author);
+        Task GetSearchResultsAsync(string searchTerm);
+        Task GetAuthorBooksAsync(string author);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -9,9 +9,9 @@ namespace WombatLibrarianApi.Services
         WombatBooksContext Context { get; }
 
         Task<IEnumerable<object>> GetBooksFromBookshelf();
+        Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
         Task<Bookshelf> AddBookToBookshelf(Book book);
         Task<IEnumerable<object>> GetBooksFromWishlist();
         Task<Wishlist> AddBookToWishlist(Book book);
-        Task<Bookshelf> GetBookShelveByIdAsync(int id);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -12,7 +12,7 @@ namespace WombatLibrarianApi.Services
         Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
         Task<Bookshelf> AddBookToBookshelfAsync(Book book);
         Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf);
-        Task<IEnumerable<object>> GetBooksFromWishlist();
-        Task<Wishlist> AddBookToWishlist(Book book);
+        Task<IEnumerable<object>> GetBooksFromWishlistAsync();
+        Task<Wishlist> AddBookToWishlistAsync(Book book);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -9,10 +9,10 @@ namespace WombatLibrarianApi.Services
         Task<IEnumerable<object>> GetBooksFromBookshelfAsync();
         Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
         Task<Bookshelf> AddBookToBookshelfAsync(Book book);
-        Task<int> RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf);
+        Task RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf);
         Task<IEnumerable<object>> GetBooksFromWishlistAsync();
         Task<Wishlist> GetWishlistItemByIdAsync(int id);
         Task<Wishlist> AddBookToWishlistAsync(Book book);
-        Task<int> RemoveBookFromWishlistByIdAsync(Wishlist wishlist);
+        Task RemoveBookFromWishlistByIdAsync(Wishlist wishlist);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -9,9 +9,10 @@ namespace WombatLibrarianApi.Services
         Task<IEnumerable<object>> GetBooksFromBookshelfAsync();
         Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
         Task<Bookshelf> AddBookToBookshelfAsync(Book book);
-        Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf);
+        Task<int> RemoveBookFromBookshelfByIdAsync(Bookshelf bookshelf);
         Task<IEnumerable<object>> GetBooksFromWishlistAsync();
         Task<Wishlist> GetWishlistItemByIdAsync(int id);
         Task<Wishlist> AddBookToWishlistAsync(Book book);
+        Task<int> RemoveBookFromWishlistByIdAsync(Wishlist wishlist);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -6,8 +6,6 @@ namespace WombatLibrarianApi.Services
 {
     public interface IBookRepository
     {
-        WombatBooksContext Context { get; }
-
         Task<IEnumerable<object>> GetBooksFromBookshelfAsync();
         Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
         Task<Bookshelf> AddBookToBookshelfAsync(Book book);

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -13,6 +13,7 @@ namespace WombatLibrarianApi.Services
         Task<Bookshelf> AddBookToBookshelfAsync(Book book);
         Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf);
         Task<IEnumerable<object>> GetBooksFromWishlistAsync();
+        Task<Wishlist> GetWishlistItemByIdAsync(int id);
         Task<Wishlist> AddBookToWishlistAsync(Book book);
     }
 }

--- a/WombatProject/Services/IBookRepository.cs
+++ b/WombatProject/Services/IBookRepository.cs
@@ -8,9 +8,10 @@ namespace WombatLibrarianApi.Services
     {
         WombatBooksContext Context { get; }
 
-        Task<IEnumerable<object>> GetBooksFromBookshelf();
+        Task<IEnumerable<object>> GetBooksFromBookshelfAsync();
         Task<Bookshelf> GetBookshelfItemByIdAsync(int id);
-        Task<Bookshelf> AddBookToBookshelf(Book book);
+        Task<Bookshelf> AddBookToBookshelfAsync(Book book);
+        Task<int> RemoveBookFromBookshelfById(Bookshelf bookshelf);
         Task<IEnumerable<object>> GetBooksFromWishlist();
         Task<Wishlist> AddBookToWishlist(Book book);
     }

--- a/WombatProject/Settings/GoogleApiSettings.cs
+++ b/WombatProject/Settings/GoogleApiSettings.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WombatLibrarianApi.Settings
+{
+    public class GoogleApiSettings
+    {
+        public string GoogleBooksURL { get; set; }
+    }
+}

--- a/WombatProject/Startup.cs
+++ b/WombatProject/Startup.cs
@@ -34,7 +34,7 @@ namespace WombatLibrarianApi
             });
             services.AddScoped<IBookAPIService, GoogleBooksAPIService>();
             services.AddScoped<IBookRepository, BookRepository>();
-            services.AddDbContext<WombatBooksContext>(opt => opt.UseSqlServer(Configuration.GetConnectionString("databaseConnection")));
+            services.AddDbContext<WombatBooksContext>();
             services.AddControllers();
             services.AddSwaggerGen();
         }

--- a/WombatProject/Startup.cs
+++ b/WombatProject/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
 using WombatLibrarianApi.Models;
 using WombatLibrarianApi.Services;
+using WombatLibrarianApi.Settings;
 
 namespace WombatLibrarianApi
 {
@@ -22,6 +23,7 @@ namespace WombatLibrarianApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<GoogleApiSettings>(Configuration.GetSection("GoogleAPI"));
             services.AddCors(options =>
             {
                 options.AddPolicy(name: MyAllowSpecificOrigins,

--- a/WombatProject/appsettings.Development.json
+++ b/WombatProject/appsettings.Development.json
@@ -1,7 +1,13 @@
 {
-  "ConnectionStrings": {
-    "databaseConnection": "data source=Localhost; initial catalog=WombatDb; integrated security=SSPI"
-  },
+  // ConnectionString was deleted because it comes from environment variables now.
+  // To set it on your computer, follow these steps (if you have Windows):
+  // windows button + R (or search for 'run' and open the Run app)
+  // rundll32 sysdm.cpl,EditEnvironmentVariables
+  // variable name : ConnectionStrings__databaseConnection
+  // vaiable value : copy here the complete connection string you used in the appsettings.json 
+  //                  (you can use localhost for data source if the db is in your computer)
+
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/WombatProject/appsettings.json
+++ b/WombatProject/appsettings.json
@@ -1,12 +1,14 @@
-{
-  "ConnectionStrings": {
-    "databaseConnection": "data source=Localhost; initial catalog=WombatDb; integrated security=SSPI"
-  },
+﻿{
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+
+  "AllowedHosts": "*",
+  "GoogleAPI": {
+    "GoogleBooksURL": "https://www.googleapis.com/books/v1/volumes"
   }
 }


### PR DESCRIPTION
With the changes on this branch there is zero direct access to the persistence layer from any the controllers. I also made some changes in the way we reach the persistence: there is no longer need for the connection string in the appsettings.json as our app uses environment variables to build a db connection. I left an instruction for setting up the environment variables in Windows, it's in the appsettings.Development.json file. I made some minor refactoring in the services to get rid of code duplications and gave more meaningful names to the methods in the controllers. I also created a settings folder with a new file: GoogleApiSettings.cs. This is a class for taking the google api url we use from the appsettings.json file, and wherever we used that directly of with magic string solutions, the app can use this settings file now so it's clearer and more professional.