### PR TITLE
Change namespace structure in Test library to make it more consistent

### DIFF
--- a/WombatTest/ControllerTests/SearchControllerTests.cs
+++ b/WombatTest/ControllerTests/SearchControllerTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using WombatLibrarianApi.Services;
 using Moq;
-using WombatTest;
 using WombatLibrarianApi.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;

--- a/WombatTest/ServiceTests/GoogleBooksAPIServiceTests.cs
+++ b/WombatTest/ServiceTests/GoogleBooksAPIServiceTests.cs
@@ -8,10 +8,9 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using WombatLibrarianApi.Services;
 using WombatLibrarianApi.Settings;
 
-namespace WombatTest
+namespace WombatLibrarianApi.Services.Tests
 {
     [TestFixture]
     public class GoogleBooksAPIServiceTests


### PR DESCRIPTION
Change namespace structure in Test library to make it more consistent